### PR TITLE
Fix incorrect joined table alias lookups.

### DIFF
--- a/classes/jelly/core/builder.php
+++ b/classes/jelly/core/builder.php
@@ -842,7 +842,11 @@ abstract class Jelly_Core_Builder extends Database_Query_Builder_Select
 		}
 
 		// Check to see if it's a known alias first
-		if (isset($this->_alias_cache[$model]))
+		if (isset($alias) and isset($this->_alias_cache[$alias]))
+		{
+			return $this->_alias_cache[$alias];
+		}
+		elseif ( ! isset($alias) and isset($this->_alias_cache[$model]))
 		{
 			return $this->_alias_cache[$model];
 		}
@@ -885,10 +889,6 @@ abstract class Jelly_Core_Builder extends Database_Query_Builder_Select
 			$this->_model_cache[$original] = array($table, $alias, $model);
 			$this->_alias_cache[$alias]    = $this->_model_cache[$original];
 		}
-
-
-
-
 
 		return $this->_model_cache[$original];
 	}


### PR DESCRIPTION
If you join any model using an alias which is the same as another model name, and then try to join the second model with a different alias, you will end up joining the first model table again with the first alias.

I've run the unit tests (on sqlite), and nothing breaks because of this change.
