### PR TITLE
select with join alias 

### DIFF
--- a/classes/jelly/core/builder.php
+++ b/classes/jelly/core/builder.php
@@ -875,9 +875,9 @@ abstract class Jelly_Core_Builder extends Database_Query_Builder_Select
 		}
 
 		// Check to see if it's a known alias first
-		if (isset($alias) and isset($this->_alias_cache[$alias]))
+		if (isset($alias) and isset($this->_alias_cache[$original]))
 		{
-			return $this->_alias_cache[$alias];
+			return $this->_alias_cache[$original];
 		}
 
 		if (strpos($model, ':') === 0)
@@ -887,9 +887,9 @@ abstract class Jelly_Core_Builder extends Database_Query_Builder_Select
 			$model = $tmp[1].$model;
 		}
 
-		if ( ! isset($alias) and isset($this->_alias_cache[$model]))
+		if ( ! isset($alias) and isset($this->_alias_cache[$original]))
 		{
-			return $this->_alias_cache[$model];
+			return $this->_alias_cache[$original];
 		}
 
 		// We're caching results to improve speed
@@ -927,7 +927,7 @@ abstract class Jelly_Core_Builder extends Database_Query_Builder_Select
 
 			// Cache what we've found
 			$this->_model_cache[$original] = array($table, $alias, $model);
-			$this->_alias_cache[$alias]    = & $this->_model_cache[$original];
+			$this->_alias_cache[$original]    = & $this->_model_cache[$original];
 		}
 
 		return $this->_model_cache[$original];


### PR DESCRIPTION
Jelly::query('page')->select_column('section.*')->join(array('page', 'section'), 'inner')->execute()->as_array();

generate sql error
"Database_Exception [ 1146 ]: Table 'gds_dev.section' doesn't exist [ SELECT `section`.\* FROM `page` AS `page` INNER JOIN `section` AS `section` ON (`page`.`id` = `section`.`pid`) ]"
