### PR TITLE
Fix/imageupload

### DIFF
--- a/classes/jelly/core/field/image.php
+++ b/classes/jelly/core/field/image.php
@@ -221,7 +221,7 @@ abstract class Jelly_Core_Field_Image extends Jelly_Field_File {
 			}
 		}
 
-		if ($this->transformations !== NULL)
+		if (count($this->transformations) > 0)
 		{
 			// Set image
 			$image = Image::factory($source, $this->driver);


### PR DESCRIPTION
Not transforming the image if no transforms have been specified. I think this is the intention of the original code but since $transformations is initialised to an empty array the original code evaluates to TRUE if you explicitly override that. I would expect it to leave the original file totally unchanged unless you've explicitly set some transforms...
